### PR TITLE
Allow manual psyq selection when autodetection fails

### DIFF
--- a/src/main/java/psyq/DetectPsyQ.java
+++ b/src/main/java/psyq/DetectPsyQ.java
@@ -13,7 +13,7 @@ public class DetectPsyQ {
 	private final static String[] PSYQ_SIG_VERSIONS = new String[] {
 			"3.6", "4.0", "4.1",
 			"4.2", "4.3", "4.4",
-	        "4.5", "4.6", "4.7"
+			"4.5", "4.6", "4.7"
 	};
 	
 	public static String getPsyqVersion(Memory mem, Address startAddress) throws MemoryAccessException, AddressOutOfBoundsException {

--- a/src/main/java/psyq/DetectPsyQ.java
+++ b/src/main/java/psyq/DetectPsyQ.java
@@ -10,6 +10,11 @@ public class DetectPsyQ {
 	private final static byte[] VERSION_BYTES = new byte[] {      0x50,       0x73,       0x07, 0x00, 0x00, 0x00, 0x47,       0x00}; // 0x47 - a version
 	private final static byte[] VERSION_MASK = new byte[]  {(byte)0xFF, (byte)0xFF, (byte)0xFF, 0x00, 0x00, 0x00, 0x00, (byte)0xF0};
 	private final static long VERSION_OFFSET = 0x06L;
+	private final static String[] PSYQ_SIG_VERSIONS = new String[] {
+			"3.6", "4.0", "4.1",
+			"4.2", "4.3", "4.4",
+	        "4.5", "4.6", "4.7"
+	};
 	
 	public static String getPsyqVersion(Memory mem, Address startAddress) throws MemoryAccessException, AddressOutOfBoundsException {
 		Address result = mem.findBytes(startAddress, VERSION_BYTES, VERSION_MASK, true, TaskMonitor.DUMMY);
@@ -17,8 +22,12 @@ public class DetectPsyQ {
 		if (result == null) {
 			return "";
 		}
-		
+
 		short version = mem.getShort(result.add(VERSION_OFFSET), true);
 		return String.format("%03X", version >> 4);
+	}
+
+	public static String[] getPsyqSigVersions() {
+		return PSYQ_SIG_VERSIONS;
 	}
 }


### PR DESCRIPTION
This adds dialogs when `DetectPsyQ.getPsyqVersion()` fails to identify the PsyQ version that prompt the user to select the version manually from a list of PsyQ versions that we have signatures for. I ran into this problem when analyzing a game that used PsyQ 3.6 but didn't have exactly the bytes specified in `VERSION_BYTES`, and I didn't want to loosen the version mask to just `0xFF 0xFF`, since that could result in too many false positives. 

I decided to hack a trailing "0" to satisfy the subversion detection on line 256 but let me know if that's too ugly for you.

![detect-psyq](https://user-images.githubusercontent.com/12201350/103705358-cd254480-4fa2-11eb-9e37-726e38be533d.png)
![selectpsyq](https://user-images.githubusercontent.com/12201350/103705368-d1e9f880-4fa2-11eb-86b5-a74cd09025c3.png)
