### PR TITLE
Adding debugger support.

### DIFF
--- a/data/languages/mips.ldefs
+++ b/data/languages/mips.ldefs
@@ -10,5 +10,8 @@
             id="PSX:LE:32:default">
     <description>PSX 32-bit addresses, little endian</description>
     <compiler name="default" spec="mips32le.cspec" id="default"/>
+    <external_name tool="gnu" name="mips:3000"/>
+    <external_name tool="IDA-PRO" name="mipsl"/>
+    <external_name tool="DWARF.register.mapping.file" name="mips.dwarf"/>
   </language>
 </language_definitions>


### PR DESCRIPTION
This will allow ghidra to properly use gdb against the PlayStation gdb stubs that exist around.