### PR TITLE
CI: Add Ghidra 11.2.x and 11.3.x builds and fix artifacts missing psyq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
           - "10.4"
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-java@v4
         with:
           java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ jobs:
     strategy:
       matrix:
         ghidra:
+          - "11.3.2"
+          - "11.3.1"
+          - "11.3"
+          - "11.2.1"
+          - "11.2"
           - "11.1.2"
           - "11.1.1"
           - "11.1"
@@ -21,10 +26,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Setup ghidra
-        uses: antoniovazquezblanco/setup-ghidra@v2.0.3
+        uses: antoniovazquezblanco/setup-ghidra@v2.0.10
         with:
           version: ${{ matrix.ghidra }}
       - name: Build Ghidra extension (using gradle)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data/psyq"]
 	path = data/psyq
-	url = ../psx_psyq_signatures
+	url = https://github.com/lab313ru/psx_psyq_signatures.git


### PR DESCRIPTION
Update CI to run on JDK 21 (recommended for Ghidra 11+)

Add targets:
          - "11.3.2"
          - "11.3.1"
          - "11.3"
          - "11.2.1"
          - "11.2"


Running was giving:
![image](https://github.com/user-attachments/assets/57527767-34af-449f-8881-1d3a2a1141b0)

This was caused by relative path submodule:
![image](https://github.com/user-attachments/assets/a9c3f35c-889c-4bf7-a236-a1a402eb64e2)

Second commit fixes this to explicitly path to your repo.
Third commit makes CI pull submodules, which means old runs never worked correctly (psyq was not included).
