### PR TITLE
CI: Add Ghidra 11.4 & Drop Pre-Ghidra 11.4 support

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
   push:
     branches:
-      - '*'
+      - 'master'
     tags:
       - '*'
 
@@ -14,19 +14,7 @@ jobs:
     strategy:
       matrix:
         ghidra:
-          - "11.3.2"
-          - "11.3.1"
-          - "11.3"
-          - "11.2.1"
-          - "11.2"
-          - "11.1.2"
-          - "11.1.1"
-          - "11.1"
-          - "11.0.3"
-          - "11.0.2"
-          - "11.0.1"
-          - "11.0"
-          - "10.4"
+          - "11.4"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +27,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup ghidra
-        uses: antoniovazquezblanco/setup-ghidra@v2.0.10
+        uses: antoniovazquezblanco/setup-ghidra@v2.0.12
         with:
           version: ${{ matrix.ghidra }}
 

--- a/src/main/java/psyq/LibgpuMacroDetector.java
+++ b/src/main/java/psyq/LibgpuMacroDetector.java
@@ -17,6 +17,7 @@ import ghidra.program.database.ProgramDB;
 import ghidra.program.database.code.CodeManager;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.CodeUnit;
+import ghidra.program.model.listing.CommentType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.FunctionManager;
 import ghidra.program.model.listing.Program;
@@ -29,7 +30,7 @@ public class LibgpuMacroDetector {
 
 	static private void SetComment(PcodeOpAST value, String comment, CodeManager codeManager) {
 		Address address = value.getSeqnum().getTarget();
-		codeManager.setComment(address, CodeUnit.PRE_COMMENT, comment);
+		codeManager.setComment(address, CommentType.PRE, comment);
 	}
 
 	static public void detectLibgpuMacros(Program program, final Address startAddr, final Address endAddr,


### PR DESCRIPTION
* Update CI to build [Ghidra 11.4](https://github.com/NationalSecurityAgency/ghidra/releases/tag/Ghidra_11.4_build)
* Update setup-ghidra 2.0.10 -> 2.0.12