### PR TITLE
Fix get_ldsxy3 registers

### DIFF
--- a/data/languages/inline_c.sinc
+++ b/data/languages/inline_c.sinc
@@ -505,7 +505,7 @@ ldclmv_3: is lhu_12_0; lhu_13_6; lhu_14_12; mtc2_12_9; mtc2_13_10; mtc2_14_11 {}
     MacroCall1($(ldclmv_idx),base);
 }
 
-:ldsxy3 RTsrc1,RTsrc2,RTsrc3  is mtc2_x_12 & RTsrc1; mtc2_x_14 & RTsrc2; mtc2_x_13 & RTsrc3 {
+:ldsxy3 RTsrc1,RTsrc2,RTsrc3  is mtc2_x_12 & RTsrc1; mtc2_x_14 & RTsrc3; mtc2_x_13 & RTsrc2 {
     gte_ldsxy3(RTsrc1,RTsrc2,RTsrc3);
 }
 


### PR DESCRIPTION
Inline macro for ldsxy3 is normally:

#define gte_ldsxy3( r0, r1, r2 ) __asm__ volatile (		\
	"mtc2	%0, $12;"					\
	"mtc2	%2, $14;"					\
	"mtc2	%1, $13"					\
	:							\
	: "r"( r0 ), "r"( r1 ), "r"( r2 ) )

But the definition in inline_c.sinc get the arguments wrong, causing the last 2 arguments to be flipped in decompilation