### PR TITLE
Make main RAM size a loader option (2/4/8/16 MB) instead of a 2 MB constant

### DIFF
--- a/src/main/java/psx/OverlayManager.java
+++ b/src/main/java/psx/OverlayManager.java
@@ -307,9 +307,10 @@ public class OverlayManager extends JPanel {
 		long addr = blockStart.getValue();
 		
 		long ramBase = program.getImageBase().getOffset();
+		long ramSize = program.getOptions(Program.PROGRAM_INFO).getLong(PsxLoader.RAM_SIZE_INFO_KEY, PsxLoader.DEF_RAM_SIZE);
 
-		if ((addr < ramBase) || (addr >= (ramBase + PsxLoader.RAM_SIZE))) {
-			provider.setStatusText(String.format("An address must be in range: %08X-%08X", ramBase, ramBase + PsxLoader.RAM_SIZE - 1));
+		if ((addr < ramBase) || (addr >= (ramBase + ramSize))) {
+			provider.setStatusText(String.format("An address must be in range: %08X-%08X", ramBase, ramBase + ramSize - 1));
 			return false;
 		}
 		

--- a/src/main/java/psx/PsxLoader.java
+++ b/src/main/java/psx/PsxLoader.java
@@ -99,7 +99,8 @@ public class PsxLoader extends AbstractLibrarySupportLoader {
 	public static final String PSX_RAM_BASE_OPTION = "RAM Base Address";
 
 	private static final long DEF_RAM_BASE = 0x80000000L;
-	public static final long RAM_SIZE = 0x200000L;
+	public static final long DEF_RAM_SIZE = 0x200000L;
+	public static final String RAM_SIZE_INFO_KEY = "PSX RAM Size";
 	private static final long __heapbase_off = -0x30;
 	private static final long initHeap_delay_off = -0x10;
 	
@@ -154,7 +155,9 @@ public class PsxLoader extends AbstractLibrarySupportLoader {
 	private static final long GPBASE_ADDR = DEF_RAM_BASE + 0x1000;
 	
 	private static final String OPTION_NAME = "RAM Base Address: ";
+	private static final String RAM_SIZE_OPTION_NAME = "RAM Size: ";
 	private long ramBase = DEF_RAM_BASE;
+	private long ramSize = DEF_RAM_SIZE;
 	
 	public static final String PSX_LANG_ID = "PSX:LE:32:default";
 	public static final String PSX_LANG_SPEC_ID = "default";
@@ -186,7 +189,8 @@ public class PsxLoader extends AbstractLibrarySupportLoader {
 		List<Option> list = new ArrayList<>();
 		
 		list.add(new PsxBaseChooser(OPTION_NAME, ramBase, PsxBaseChooser.class, Loader.COMMAND_LINE_ARG_PREFIX + "-ramStart"));
-		
+		list.add(new PsxSizeChooser(RAM_SIZE_OPTION_NAME, String.format("0x%X", ramSize), PsxSizeChooser.class, Loader.COMMAND_LINE_ARG_PREFIX + "-ramSize"));
+
 		return list;
 	}
 	
@@ -196,7 +200,8 @@ public class PsxLoader extends AbstractLibrarySupportLoader {
 			String optName = option.getName();
 			if (optName.equals(OPTION_NAME)) {
 				ramBase = Long.decode((String)option.getValue());
-				break;
+			} else if (optName.equals(RAM_SIZE_OPTION_NAME)) {
+				ramSize = Long.decode((String)option.getValue());
 			}
 		}
 
@@ -208,6 +213,8 @@ public class PsxLoader extends AbstractLibrarySupportLoader {
 		
 		Options aOpts = program.getOptions(Program.ANALYSIS_PROPERTIES);
 		aOpts.setBoolean("Non-Returning Functions - Discovered", false);
+
+		program.getOptions(Program.PROGRAM_INFO).setLong(RAM_SIZE_INFO_KEY, ramSize);
 
 		if (!psxExe.isParsed()) {
 			settings.monitor().setMessage(String.format("%s : Cannot load", getName()));
@@ -775,9 +782,13 @@ public class PsxLoader extends AbstractLibrarySupportLoader {
 		}
 		
 		long code_end = psxExe.getRomEnd();
-		long ram_size_2 = ramBase + RAM_SIZE - code_end;
-		createSegment(fpa, null, "RAM", code_end, ram_size_2, false, true, log);
-		res.add(new AddressRangeImpl(fpa.toAddr(code_end), ram_size_2));
+		long ram_size_2 = ramBase + ramSize - code_end;
+		if (ram_size_2 > 0) {
+			createSegment(fpa, null, "RAM", code_end, ram_size_2, false, true, log);
+			res.add(new AddressRangeImpl(fpa.toAddr(code_end), ram_size_2));
+		} else {
+			log.appendMsg(String.format("Selected RAM size (0x%X) is smaller than the loaded image (ends at 0x%08X); trailing RAM block skipped.", ramSize, code_end));
+		}
 		
 		createSegment(fpa, null, "CACHE", 0x1F800000L, 0x400, true, true, log);
 		createSegment(fpa, null, "UNK1", 0x1F800400L, 0xC00, true, true, log);

--- a/src/main/java/psx/PsxSizeChooser.java
+++ b/src/main/java/psx/PsxSizeChooser.java
@@ -1,0 +1,62 @@
+package psx;
+
+import java.awt.Component;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.JComboBox;
+
+import ghidra.app.util.Option;
+
+public class PsxSizeChooser extends Option {
+
+	private String selected;
+	private String[] items = new String[] {
+			"0x200000",  // 2 MB - retail console
+			"0x400000",  // 4 MB - arcade board
+			"0x800000",  // 8 MB - development kit
+			"0x1000000", // 16 MB - arcade board
+	};
+
+	private JComboBox<String> editor = new JComboBox<>(items);
+
+	public PsxSizeChooser(String name, Object value, Class<?> valueClass, String arg) {
+		super(name, valueClass, value, arg, null);
+
+		selected = items[0];
+
+		editor.addItemListener(new ItemListener() {
+
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				if (e.getStateChange() == ItemEvent.SELECTED) {
+						selected = (String)e.getItem();
+						PsxSizeChooser.super.setValue(selected);
+			       }
+			}
+
+		});
+
+		editor.setEditable(false);
+	}
+
+	@Override
+	public Component getCustomEditorComponent() {
+		return editor;
+	}
+
+	@Override
+	public Option copy() {
+		return new PsxSizeChooser(getName(), getValue(), getValueClass(), getArg());
+	}
+
+	@Override
+	public Object getValue() {
+		return selected;
+	}
+
+	@Override
+	public Class<?> getValueClass() {
+		return String.class;
+	}
+}


### PR DESCRIPTION
The loader hardcoded main RAM to 2 MB (`RAM_SIZE = 0x200000`). That is correct for a retail console, but PS1-based hardware ships other sizes: 8 MB on development kits, 4 MB and 16 MB on arcade boards (System 573, Twinkle, etc.). Importing an executable that loads into the upper RAM those boards use made the trailing RAM block length (`ramBase + RAM_SIZE - code_end`) go negative and the import failed.

RAM size is now a loader option: a "RAM Size" dropdown constrained to the four hardware-valid sizes, defaulting to 2 MB so existing retail imports are unchanged. It is deliberately not auto-detected, since arcade executables often occupy well under their board's RAM while still referencing the upper regions at runtime, so the image extent cannot tell you the real size. The chosen size is stored in `PROGRAM_INFO` so `OverlayManager`'s range check tracks it, and an image larger than the selection skips the trailing block with a log message instead of failing on a negative length.

Tested against the System 573 700A01 shell (loads at `0x803C0000`): the trailing block is skipped at 2 MB and mapped correctly at 4 MB.

- New `PsxSizeChooser` mirrors the existing `PsxBaseChooser` combo.
